### PR TITLE
Fix "FusekiDataClient.drop_all(self, ds_name)"

### DIFF
--- a/fuseki_manager/api_client.py
+++ b/fuseki_manager/api_client.py
@@ -387,9 +387,9 @@ class FusekiDataClient(FusekiBaseClient):
         :param str ds_name: Dataset's name.
         :returns bool: True if all data is removed without errors.
         """
-        uri = self._build_uri(ds_name)
+        uri = self._build_uri(ds_name, service_name='update')
         query_params = {'update': 'DROP ALL'}
-        self._post(uri, params=query_params, expected_status=(200, 204,))
+        self._post(uri, data=query_params, expected_status=(200, 204,))
         return True
 
     def upload_files(self, ds_name, file_paths):


### PR DESCRIPTION

## Problem

drop_all() method not working. Fuseki return 204 but data are still in dataset.

Fuseki logs:

```
Fuseki     INFO  [1] POST http://localhost:3030/dataset_name?update=DROP+ALL
Fuseki     WARN  SPARQL Update: Unrecognized request parameter (ignored): update
Fuseki     INFO  [1] 204 No Content (6 ms)
```

## Solution

Change endpoint. Use ``/dataset_name/update`` endpoint.
POST arguments with "data" (in body) instead of "params" (in url).

Fuseki logs

```
Fuseki     INFO  [2] POST http://localhost:3030/dataset_name/update
Fuseki     INFO  [2] 200 OK (681 ms)
```